### PR TITLE
Fix double page mode crash with vo=libmpv and add .cbr to ext array

### DIFF
--- a/manga-reader.lua
+++ b/manga-reader.lua
@@ -4,6 +4,7 @@ local ext = {
 	".7z",
 	".avif",
 	".bmp",
+	".cbr",
 	".cbz",
 	".gif",
 	".jpg",

--- a/manga-reader.lua
+++ b/manga-reader.lua
@@ -85,6 +85,8 @@ function check_aspect_ratio(index)
 		display_width = display_width / display_dpi
 		display_height = display_height / display_dpi
 		aspect_ratio = display_width / display_height
+	else
+		return true
 	end
 	if m/n <= aspect_ratio then
 		return true
@@ -170,16 +172,11 @@ function store_file_dims(start, finish)
 		filedims[i+start] = dims
 	end
 	for i=start, finish - 1 do
-		local good_aspect_ratio = check_aspect_ratio(i)
+		valid_width[i] = check_aspect_ratio(i)
 		if math.abs(filedims[i][1] - filedims[i+1][1]) < opts.similar_height_threshold then
 			similar_height[i] = true
 		else
 			similar_height[i] = false
-		end
-		if not good_aspect_ratio then
-			valid_width[i] = false
-		else
-			valid_width[i] = true
 		end
 	end
 end


### PR DESCRIPTION
When using a vo that doesn't support `display-width` and `display-height`, the `aspect_ratio` variable is compared to a number while uninitialized. This leads to the script crashing.

This fixes the issue by returning `true` out of `check_aspect_ratio()` when `display-width` or `display-height` returns `nil`. This produces desirable behavior in most cases since it doesn't lock out `vo`s where aspect ratio is inaccessible from using double page mode.

---

Add `.cbr` to the extension array. It appears to be a format that's just a wrapper around some standard archive format, so it works without tweaking in mpv.