### PR TITLE
add bindings for MBTN_FORWARD/BACK

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ By default, starting mpv-manga-reader is bound to `y`. When turning the reader o
 * toggle-manga-mode: `m`
 * next-page: `LEFT`
 * prev-page: `RIGHT`
+* next-page-mouse: `MBTN_FORWARD`
+* prev-page-mouse: `MBTN_BACK`
 * next-single-page: `Shift+LEFT`
 * prev-single-page: `Shift+RIGHT`
 * skip-forward: `Ctrl+LEFT`

--- a/manga-reader.lua
+++ b/manga-reader.lua
@@ -579,6 +579,8 @@ function set_keys()
 	mp.add_forced_key_binding("DOWN", "pan-down", pan_down, "repeatable")
 	mp.add_forced_key_binding("HOME", "first-page", first_page)
 	mp.add_forced_key_binding("END", "last-page", last_page)
+	mp.add_forced_key_binding("MBTN_FORWARD", "next-page-mouse", next_page)
+	mp.add_forced_key_binding("MBTN_BACK", "prev-page-mouse", prev_page)
 	mp.add_forced_key_binding("/", "jump-page-mode", jump_page_mode)
 end
 
@@ -593,6 +595,8 @@ function remove_keys()
 	mp.remove_key_binding("pan-down")
 	mp.remove_key_binding("first-page")
 	mp.remove_key_binding("last-page")
+	mp.remove_key_binding("next-page-mouse")
+	mp.remove_key_binding("prev-page-mouse")
 	mp.remove_key_binding("jump-page-mode")
 end
 


### PR DESCRIPTION
These keys are bound to playlist-next/prev by default but in double or continuous mode they will behave in an unexpected way.